### PR TITLE
Use fontawesome icons instead of simplesharebuttons

### DIFF
--- a/css/sunburst.css
+++ b/css/sunburst.css
@@ -50,7 +50,7 @@ form {
     float: right;
 }
 
-#share-buttons img {
+#share-buttons i {
     width: 23px;
     padding: 3px;
     border: 0;

--- a/index.html
+++ b/index.html
@@ -34,22 +34,22 @@
             <h1 id="headline"></h1>
             <div id="share-buttons">
                 <!-- Facebook -->
-                <a href="http://www.facebook.com/sharer.php?u=http://schoolbudget.phl.io/" target="_blank"><img src="http://www.simplesharebuttons.com/images/somacro/facebook.png" alt="Facebook" /></a>
+                <a href="http://www.facebook.com/sharer.php?u=http://schoolbudget.phl.io/" target="_blank"><i class="fa fa-facebook fa-2x" alt="Facebook"></i></a>
 
                 <!-- Twitter -->
-                <a href="http://twitter.com/share?url=http://schoolbudget.phl.io/&text=School District of Philadelphia Budget Visualization" target="_blank"><img src="http://www.simplesharebuttons.com/images/somacro/twitter.png" alt="Twitter" /></a>
+                <a href="http://twitter.com/share?url=http://schoolbudget.phl.io/&text=School District of Philadelphia Budget Visualization" target="_blank"><i class="fa fa-twitter fa-2x" alt="Twitter"></i></a>
 
                 <!-- Google+ -->
-                <a href="https://plus.google.com/share?url=http://schoolbudget.phl.io/" target="_blank"><img src="http://www.simplesharebuttons.com/images/somacro/google.png" alt="Google" /></a>
+                <a href="https://plus.google.com/share?url=http://schoolbudget.phl.io/" target="_blank"><i class="fa fa-google fa-2x" alt="Google"></i></a>
 
                 <!-- Reddit -->
-                <a href="http://reddit.com/submit?url=http://schoolbudget.phl.io/&title=School District of Philadelphia Budget Visualization" target="_blank"><img src="http://www.simplesharebuttons.com/images/somacro/reddit.png" alt="Reddit" /></a>
+                <a href="http://reddit.com/submit?url=http://schoolbudget.phl.io/&title=School District of Philadelphia Budget Visualization" target="_blank"><i class="fa fa-reddit fa-2x" alt="Reddit"></i></a>
 
                 <!-- LinkedIn -->
-                <a href="http://www.linkedin.com/shareArticle?mini=true&url=http://schoolbudget.phl.io/" target="_blank"><img src="http://www.simplesharebuttons.com/images/somacro/linkedin.png" alt="LinkedIn" /></a>
+                <a href="http://www.linkedin.com/shareArticle?mini=true&url=http://schoolbudget.phl.io/" target="_blank"><i class="fa fa-linkedin fa-2x" alt="LinkedIn"></i></a>
 
                 <!-- Email -->
-                <a href="mailto:?Subject=School District Budget&Body=School%20District%20Budget%20Visualization%20 http://schoolbudget.phl.io/"><img src="http://www.simplesharebuttons.com/images/somacro/email.png" alt="Email" /></a>
+                <a href="mailto:?Subject=School District Budget&Body=School%20District%20Budget%20Visualization%20 http://schoolbudget.phl.io/"><i class="fa fa-envelope-o fa-2x" alt="Email"></i></a>
             </div>
             <form>
                 <div>
@@ -91,5 +91,6 @@
         </div>
         <script src="js/d3.min.js"></script>
         <script src="js/sunburst.js"></script>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     </body>
 </html>


### PR DESCRIPTION
simplesharebuttons have an invalid certificate that prevents the pngs from being loaded securely. Swap to the popular FontAwesome package to get social icons.

<img width="304" alt="screen shot 2016-03-07 at 1 12 51 am" src="https://cloud.githubusercontent.com/assets/4812055/13562794/bd48d23c-e401-11e5-9009-7c1113b4a9b1.png">

Includes changed all share buttons from img to i, and updating the css to reference i instead of img in the shared-buttons sections.

Closes #16.
